### PR TITLE
Address hyperlink spelling mismatch

### DIFF
--- a/src/components/compatibility.astro
+++ b/src/components/compatibility.astro
@@ -107,7 +107,7 @@ const frameworks: Array<ImageMetadata> = [
 ];
 ---
 
-<ContentSection title="Integrations" id="Integrations">
+<ContentSection title="Integrations" id="integrations">
   <Fragment slot="lead">
     MeetingBar supports <span class="text-primary">50+</span> meeting services.
   </Fragment>


### PR DESCRIPTION
### Status
**READY**

### Description

Noticed that [https://meetingbar.app/#integrations](https://meetingbar.app/#integrations) didn't link properly because the id in the section was uppercase and the anchor in the nav was lowercase. 
`<ContentSection title="Integrations" id="Integrations">` 
vs 
`  { title: "Integrations", url: "#integrations" },`

Updated the id in the section to lowercase.

Edit: Confirmed in [the build preview](https://meeting-bar-site-git-fork-bgjoo-89cb09-andrii-leitsius-projects.vercel.app)

Hope you don't mind the pull request here. Please let me know if I missed anything.

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

- npm ci
- npm run dev
- Navigate to [http://localhost:3000/](http://localhost:3000/)
- Click on "Integrations" and observe that the page scrolls down to the appropriate tag